### PR TITLE
Adding Mosquitto repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@ MAINTAINER Jan-Piet Mens <jpmens@gmail.com>
 RUN apt-get update && apt-get install -y wget && \
 	wget -q -O /tmp/owntracks.gpg.key http://repo.owntracks.org/repo.owntracks.org.gpg.key && \
 	apt-key add /tmp/owntracks.gpg.key
+RUN wget -q -O /tmp/mosquitto.gpg.key http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key && \
+    apt-key add /tmp/mosquitto.gpg.key
 RUN apt-get install -y software-properties-common && \
 	apt-add-repository 'deb http://repo.owntracks.org/debian jessie main' && \
+	apt-add-repository 'deb http://repo.mosquitto.org/debian jessie main' && \
 	apt-get update && \
 	apt-get install -y \
 		libmosquitto1 \


### PR DESCRIPTION
I have used Mosquitto 1.4 for a year, moved many services to docker now and it came recorderd docker image uses Mosquitto from Jessie repo.
Why dont we use something fresh :)
Docker image builds with success and starts. No further tests though.