### PR TITLE
Expose browser-apikey via environment variable

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,5 @@ docker run -v /tmp/o2:/owntracks -p 11883:1883 -p 18883:8883 -p 8083:8083 \
 	-e MQTTHOSTNAME="${cthostname}" \
 	-e IPLIST="192.168.1.1 127.0.0.83 192.168.1.82" \
 	-e HOSTLIST="foo.example.com bar.org.example.com ${cthostname}" \
+	-e OTR_BROWSERAPIKEY="replace-me" \
 	owntracks/recorderd

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -20,7 +20,7 @@ auto_start=true
 autorestart=true
 
 [program:recorder]
-command=/usr/sbin/ot-recorder --http-host 0.0.0.0 'owntracks/#'
+command=/usr/sbin/ot-recorder --http-host 0.0.0.0 --browser-apikey %(ENV_OTR_BROWSERAPIKEY)s 'owntracks/#'
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
The [recorder README](https://github.com/owntracks/recorder/blob/master/README.md#configuration-file) states that `OTR_BROWSERAPIKEY` can be set to override the Google maps browser API key. Passing it to the Docker container does not seem to work with the current version of supervisord. The following snippet should have worked, but it does not:

```
[program:recorder]
environment=ENV_OTR_BROWSERAPIKEY=%(ENV_OTR_BROWSERAPIKEY)s
command=/usr/sbin/ot-recorder --http-host 0.0.0.0 'owntracks/#'
```

It can be checked pretty quickly after starting the container with `curl http://my-docker-host:8083/static/apikey.js`, which is still having an empty api key. There is some more evidence on supervisord's env issues [in this SO thread](http://stackoverflow.com/a/38690097/3212907).

This PR works around the issue by adding `--browser-apikey` to the invocation of `ot-recorder` in `supervisord.conf`, reading the value from the `OTR_BROWSERAPIKEY` environment variable. This, btw, which proves that passing the environment value from `docker -e` to supervisord works in general.

A change to `run.sh` shows how to set this environment variable.

It is possible that this is a bug in owntracks/recorder, but I was unable to reproduce it there.